### PR TITLE
Add region check functions for locale identification

### DIFF
--- a/assets/root/localeinfo.py
+++ b/assets/root/localeinfo.py
@@ -354,3 +354,31 @@ def SecondToHM(time):
 	if minute > 0:
 		text += str(minute) + MINUTE
 	return text
+
+# Region check functions
+def IsEUROPE():
+    return app.GetLocaleName() in ["de", "fr", "it", "es", "pt", "pl", "cz", "ro", "hu", "nl", "dk", "gr", "tr", "ru"]
+
+def IsCANADA():
+    return False  # Not used in this setup
+
+def IsJAPAN():
+    return app.GetLocaleName() == "jp"
+
+def IsENGLISH():
+    return app.GetLocaleName() == "en"
+
+def IsCHINA():
+    return app.GetLocaleName() in ["cn", "tw", "hk"]
+
+def IsHONGKONG():
+    return app.GetLocaleName() == "hk"
+
+def IsTAIWAN():
+    return app.GetLocaleName() == "tw"
+
+def IsNEWCIBN():
+    return False  # China-specific, not used
+
+def IsARABIC():
+    return app.GetLocaleName() == "ae"


### PR DESCRIPTION
## Fix missing locale region check functions

### Problem
Client crashes with `AttributeError` when hovering over items due to missing locale region check functions (`IsCANADA`, `IsEUROPE`, `IsARABIC`, etc.) in `localeinfo.py`.

### Changes
- Added all required locale region check functions to `localeinfo.py`
- Functions now dynamically check the active locale using `app.GetLocaleName()`
- `IsEUROPE()` returns `True` for European locales (de, fr, it, es, pt, pl, cz, ro, hu, nl, dk, gr, tr, ru)
- `IsARABIC()` returns `True` for Arabic locale (ae) - fixes metin socket rendering
- Other functions check specific locales or return `False` for unused regions

### Files Modified
- `m2dev-client/assets/root/localeinfo.py`

### Testing
- ✅ Tooltips now display correctly without errors
- ✅ Metin socket slots render properly on equipment
- ✅ Multi-language support works correctly
