### PR TITLE
Fix bug where we cant split item stacks

### DIFF
--- a/assets/root/uipickmoney.py
+++ b/assets/root/uipickmoney.py
@@ -1,7 +1,7 @@
 import wndMgr
 import ui
 import ime
-import localeInfo
+import app
 
 class PickMoneyDialog(ui.ScriptWindow):
 	def __init__(self):


### PR DESCRIPTION
Missing import was causing fail to open the ui dialog