### PR TITLE
FIX: Always load locale data at first start

### DIFF
--- a/assets/root/localeinfo.py
+++ b/assets/root/localeinfo.py
@@ -113,6 +113,13 @@ def LoadLocaleFile(srcFileName, localeDict):
 
 LoadLocaleFile("{:s}/locale_game.txt".format(APP_GET_LOCALE_PATH), locals())
 
+try:
+    currentLocalePath = app.GetLocalePath()
+    if not app.LoadLocaleData(currentLocalePath):
+        dbg.TraceError("localeInfo: Failed to load C++ locale data from %s" % currentLocalePath)
+except Exception, e:
+    dbg.TraceError("localeInfo: Error loading C++ locale data: %s" % str(e))
+
 # Option pvp messages
 OPTION_PVPMODE_MESSAGE_DICT = {
 	0: PVP_MODE_NORMAL,


### PR DESCRIPTION
We always load locale data after loading default locale, to avoid missing data and crash when player does not change his language

Bug fixed:
(all these are reproducible by not changing language after starting client)
- Character creation shows naked characters
- Infinite loading screen
- During loading screen, Experience percentage localization label is shown instead of pointer