### PR TITLE
FIX: Ensure belt window is displayed above other windows when inventory is opened

### DIFF
--- a/assets/root/uiinventory.py
+++ b/assets/root/uiinventory.py
@@ -108,6 +108,8 @@ class BeltInventoryWindow(ui.ScriptWindow):
 			 	 
 		ui.ScriptWindow.__init__(self)
 
+		self.AddFlag("float")
+
 		self.isLoaded = 0
 		self.wndInventory = wndInventory
 		
@@ -1105,6 +1107,9 @@ class InventoryWindow(ui.ScriptWindow):
 	def OnTop(self):
 		if None != self.tooltipItem:
 			self.tooltipItem.SetTop()
+
+		if self.wndBelt:
+			self.wndBelt.SetTop()
 
 	def OnPressEscapeKey(self):
 		self.Close()


### PR DESCRIPTION
<img width="234" height="289" alt="immagine" src="https://github.com/user-attachments/assets/844ebdbd-e56b-48f9-a02c-287ca8db88c1" />
<img width="565" height="550" alt="immagine" src="https://github.com/user-attachments/assets/8be9ed69-0bda-4d81-8d1e-f0888b463296" />

The images are pretty self explainatory
Fixes the bug that made the belt inventory to be never on top relative to other windows