### PR TITLE
Reverted OnIMEUpdate to use TextLine.SetText

### DIFF
--- a/assets/root/ui.py
+++ b/assets/root/ui.py
@@ -778,7 +778,7 @@ class EditLine(TextLine):
 
 	def OnIMEUpdate(self):
 		snd.PlaySound("sound/ui/type.wav")
-		self.SetText(ime.GetText())
+		TextLine.SetText(self, ime.GetText())
 
 	def OnIMETab(self):
 		if self.eventTab:


### PR DESCRIPTION
It seems to fix the cursor issue on textboxes.

fix: avoid IME ↔ EditLine loop

Previously, `OnIMEUpdate` used `EditLine.SetText`, which, when the control has focus, also calls `ime.SetText`. Since `OnIMEUpdate` is already invoked by the IME after its internal buffer is updated, sending the same text back into the IME creates an unnecessary and potentially unstable synchronization loop. We now use `TextLine.SetText(self, ime.GetText())` to update only the UI without touching the IME’s internal state.

@rtw1x1 please verify it because it is a revert from your merge